### PR TITLE
honor go vet

### DIFF
--- a/cmds/catalog.go
+++ b/cmds/catalog.go
@@ -70,7 +70,7 @@ func schemaTableGet(c *cli.Context) error {
 		val := item
 		list[i] = &val
 	}
-	resultWrite(c, list, fmt.Sprintf("schema_table_%s"))
+	resultWrite(c, list, fmt.Sprintf("schema_table_%s", id))
 	return nil
 }
 func schemaTableList(c *cli.Context) error {

--- a/cmds/watchlql.go
+++ b/cmds/watchlql.go
@@ -125,7 +125,6 @@ func (l *lql) print(d *datafile) {
 	}
 	if len(d.lql) == 0 {
 		l.printUsingCurrentQueries(d)
-		return
 		log.Printf("No lql found for %v \n\n", d.name)
 		return
 	}


### PR DESCRIPTION
closes n/a

fixes bad output filename `schema_table_%!s(MISSING).csv`
removed `return` before error message

```
➜  lytics git:(develop) ✗ go vet ./cmds/*.go
cmds/catalog.go:73:23: Sprintf format %s reads arg #1, but call has 0 args
cmds/watchlql.go:129:3: unreachable code
```